### PR TITLE
initial commit of refactor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,6 @@ before_script:
 
 script:
   - if [[ "$PHP_LINT" == "1" ]]; then find . -type "f" -iname "*.php" -not -path "./vendor/*" | xargs -L "1" php -l; fi
-  - if [[ "$WP_PHPCS" == "1" ]]; then phpcs -p -s -v -n --standard=./codesniffer.ruleset.xml --extensions=php .; fi
+  - if [[ "$WP_PHPCS" == "1" ]]; then phpcs -p -s -v -n --standard=./phpcs.ruleset.xml --extensions=php .; fi
   - phpunit
   - phpunit -c multisite.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,46 @@
+sudo: false
+
+language: php
+
+notifications:
+  email:
+    on_success: never
+    on_failure: change
+
+branches:
+  only:
+    - master
+    - mvp
+
+matrix:
+  include:
+    - php: 5.4
+      env: WP_VERSION=4.6 PHP_LINT=1
+    - php: 5.6
+      env: WP_VERSION=latest PHP_LINT=1
+    - php: 7.0
+      env: WP_VERSION=latest PHP_LINT=1 WP_PHPCS=1
+    - php: 7.0
+      env: WP_VERSION=nightly
+    - php: 'hhvm'
+      env: WP_VERSION=nightly PHP_LINT=1
+  fast_finish: true
+
+before_script:
+  - |
+    if [[ ! -z "$WP_VERSION" ]] ; then
+      bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
+    fi
+  - |
+    if [[ "$WP_PHPCS" == "1" ]]; then
+      composer install
+      export PATH=$PATH:${PWD}/vendor/bin/
+      # After CodeSniffer install you should refresh your path.
+      phpenv rehash
+    fi
+
+script:
+  - if [[ "$PHP_LINT" == "1" ]]; then find . -type "f" -iname "*.php" -not -path "./vendor/*" | xargs -L "1" php -l; fi
+  - if [[ "$WP_PHPCS" == "1" ]]; then phpcs -p -s -v -n --standard=./codesniffer.ruleset.xml --extensions=php .; fi
+  - phpunit
+  - phpunit -c multisite.xml

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+
+if [ $# -lt 3 ]; then
+	echo "usage: $0 <db-name> <db-user> <db-pass> [db-host] [wp-version] [skip-database-creation]"
+	exit 1
+fi
+
+DB_NAME=$1
+DB_USER=$2
+DB_PASS=$3
+DB_HOST=${4-localhost}
+WP_VERSION=${5-latest}
+SKIP_DB_CREATE=${6-false}
+
+WP_TESTS_DIR=${WP_TESTS_DIR-/tmp/wordpress-tests-lib}
+WP_CORE_DIR=${WP_CORE_DIR-/tmp/wordpress/}
+
+download() {
+    if [ `which curl` ]; then
+        curl -s "$1" > "$2";
+    elif [ `which wget` ]; then
+        wget -nv -O "$2" "$1"
+    fi
+}
+
+if [[ $WP_VERSION =~ [0-9]+\.[0-9]+(\.[0-9]+)? ]]; then
+	WP_TESTS_TAG="tags/$WP_VERSION"
+elif [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
+	WP_TESTS_TAG="trunk"
+else
+	# http serves a single offer, whereas https serves multiple. we only want one
+	download http://api.wordpress.org/core/version-check/1.7/ /tmp/wp-latest.json
+	grep '[0-9]+\.[0-9]+(\.[0-9]+)?' /tmp/wp-latest.json
+	LATEST_VERSION=$(grep -o '"version":"[^"]*' /tmp/wp-latest.json | sed 's/"version":"//')
+	if [[ -z "$LATEST_VERSION" ]]; then
+		echo "Latest WordPress version could not be found"
+		exit 1
+	fi
+	WP_TESTS_TAG="tags/$LATEST_VERSION"
+fi
+
+set -ex
+
+install_wp() {
+
+	if [ -d $WP_CORE_DIR ]; then
+		return;
+	fi
+
+	mkdir -p $WP_CORE_DIR
+
+	if [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
+		mkdir -p /tmp/wordpress-nightly
+		download https://wordpress.org/nightly-builds/wordpress-latest.zip  /tmp/wordpress-nightly/wordpress-nightly.zip
+		unzip -q /tmp/wordpress-nightly/wordpress-nightly.zip -d /tmp/wordpress-nightly/
+		mv /tmp/wordpress-nightly/wordpress/* $WP_CORE_DIR
+	else
+		if [ $WP_VERSION == 'latest' ]; then
+			local ARCHIVE_NAME='latest'
+		else
+			local ARCHIVE_NAME="wordpress-$WP_VERSION"
+		fi
+		download https://wordpress.org/${ARCHIVE_NAME}.tar.gz  /tmp/wordpress.tar.gz
+		tar --strip-components=1 -zxmf /tmp/wordpress.tar.gz -C $WP_CORE_DIR
+	fi
+
+	download https://raw.github.com/markoheijnen/wp-mysqli/master/db.php $WP_CORE_DIR/wp-content/db.php
+}
+
+install_test_suite() {
+	# portable in-place argument for both GNU sed and Mac OSX sed
+	if [[ $(uname -s) == 'Darwin' ]]; then
+		local ioption='-i .bak'
+	else
+		local ioption='-i'
+	fi
+
+	# set up testing suite if it doesn't yet exist
+	if [ ! -d $WP_TESTS_DIR ]; then
+		# set up testing suite
+		mkdir -p $WP_TESTS_DIR
+		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR/includes
+		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data/ $WP_TESTS_DIR/data
+	fi
+
+	if [ ! -f wp-tests-config.php ]; then
+		download https://develop.svn.wordpress.org/${WP_TESTS_TAG}/wp-tests-config-sample.php "$WP_TESTS_DIR"/wp-tests-config.php
+		# remove all forward slashes in the end
+		WP_CORE_DIR=$(echo $WP_CORE_DIR | sed "s:/\+$::")
+		sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR/':" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/yourusernamehere/$DB_USER/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/yourpasswordhere/$DB_PASS/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s|localhost|${DB_HOST}|" "$WP_TESTS_DIR"/wp-tests-config.php
+	fi
+
+}
+
+install_db() {
+
+	if [ ${SKIP_DB_CREATE} = "true" ]; then
+		return 0
+	fi
+
+	# parse DB_HOST for port or socket references
+	local PARTS=(${DB_HOST//\:/ })
+	local DB_HOSTNAME=${PARTS[0]};
+	local DB_SOCK_OR_PORT=${PARTS[1]};
+	local EXTRA=""
+
+	if ! [ -z $DB_HOSTNAME ] ; then
+		if [ $(echo $DB_SOCK_OR_PORT | grep -e '^[0-9]\{1,\}$') ]; then
+			EXTRA=" --host=$DB_HOSTNAME --port=$DB_SOCK_OR_PORT --protocol=tcp"
+		elif ! [ -z $DB_SOCK_OR_PORT ] ; then
+			EXTRA=" --socket=$DB_SOCK_OR_PORT"
+		elif ! [ -z $DB_HOSTNAME ] ; then
+			EXTRA=" --host=$DB_HOSTNAME --protocol=tcp"
+		fi
+	fi
+
+	# create database
+	mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
+}
+
+install_wp
+install_test_suite
+install_db

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,17 @@
+{
+  "name": "alleyinteractive/postrelease-vip",
+  "authors": [
+    {
+      "name": "Matthew Boynes",
+      "email": "noreply@alleyinteractive.com"
+    }
+  ],
+  "require-dev": {
+    "squizlabs/php_codesniffer": "2.*",
+    "wp-coding-standards/wpcs": "dev-master"
+  },
+  "scripts": {
+    "post-install-cmd": "\"vendor/bin/phpcs\" --config-set installed_paths vendor/wp-coding-standards/wpcs",
+    "post-update-cmd": "\"vendor/bin/phpcs\" --config-set installed_paths vendor/wp-coding-standards/wpcs"
+  }
+}

--- a/config.php
+++ b/config.php
@@ -1,4 +1,0 @@
-<?php
-define('PRX_DEV', false); //set to false in production (when equals true: disables security check)
-define('PRX_POSTRELEASE_SERVER','http://www.postrelease.com');
-define('PRX_JAVASCRIPT_URL','http://a.postrelease.com/serve/load.js?async=true'); //http://a.postrelease.com/serve/load.js?async=true

--- a/multisite.xml
+++ b/multisite.xml
@@ -1,0 +1,17 @@
+<phpunit
+	bootstrap="tests/bootstrap.php"
+	backupGlobals="false"
+	colors="true"
+	convertErrorsToExceptions="true"
+	convertNoticesToExceptions="true"
+	convertWarningsToExceptions="true"
+	>
+	<php>
+		<const name="WP_TESTS_MULTISITE" value="1" />
+	</php>
+	<testsuites>
+		<testsuite>
+			<directory prefix="test-" suffix=".php">tests</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/phpcs.ruleset.xml
+++ b/phpcs.ruleset.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<ruleset name="nativo">
+	<description>Sniffs for the coding standards of the Nativo plugin</description>
+
+	<exclude-pattern>tests/*</exclude-pattern>
+	<exclude-pattern>vendor/*</exclude-pattern>
+	<exclude-pattern>node_modules/*</exclude-pattern>
+
+	<rule ref="WordPress-VIP">
+	</rule>
+</ruleset>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,14 @@
+<phpunit
+	bootstrap="tests/bootstrap.php"
+	backupGlobals="false"
+	colors="true"
+	convertErrorsToExceptions="true"
+	convertNoticesToExceptions="true"
+	convertWarningsToExceptions="true"
+	>
+	<testsuites>
+		<testsuite>
+			<directory prefix="test-" suffix=".php">./tests/</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/postrelease-vip.php
+++ b/postrelease-vip.php
@@ -2,567 +2,680 @@
 /*
  Plugin Name: PostRelease VIP
  Plugin URI: http://www.postrelease.com
- Description: PostRelease VIP
- Version: 1.2
+ Description: A plugin to handle navtive ads through Nativo
+ Version: 1.3
  Author: PostRelease
  Author URI: http://www.postrelease.com
  */
- 
-/*
-+-----------------------------------------------------------------------------------------
-| Version | Date       | Notes
-|---------|-------------------------------------------------------------------------------
-| 1.0     | 2012/08/01 | First release live
-| 1.1     | 2012/10/05 | Returning blog URL as the blog name as fallback
-| 1.2     | 2012/10/08 | Added filters for date and author (display as Promoted)
-+-----------------------------------------------------------------------------------------
-*/
- 
-define('PRX_CUSTOM_TYPE', 'pr_sponsored_post'); //custom post type created for our template post 
-define('PRX_WP_PLUGIN_VERSION', '1.2');
-define('PRX_DB_VERSION', 1);
+if ( ! class_exists( PostRelease_VIP ) ) :
 
-require_once( dirname(__FILE__) .'/config.php' );
+	class PostRelease_VIP {
 
-add_action('init', 'postrelease_init');
-add_action('init', 'postrelease_handle_enable_request' );
-add_action('init', 'postrelease_handle_signup_requests');
-add_action('admin_init', 'postrelease_admin_init');
-add_action('wp_enqueue_scripts', 'postrelease_wp_enqueue_scripts', 1);
-add_action('admin_menu', 'postrelease_create_menu'); // create custom plugin settings menu
-add_filter('query_vars', 'postrelease_add_query_vars');
-add_action('template_redirect', 'postrelease_template_redirect');
-add_action('the_author', 'postrelease_the_author');
-add_filter('author_link', 'postrelease_author_link', 100, 2);
-add_action('the_author_display_name', 'postrelease_the_author_display_name');
-add_filter('get_the_date', 'postrelease_get_the_date', 10, 2);
-add_filter('get_the_time', 'postrelease_get_the_time', 10, 2);
+		/**
+		 * The one instance of PostRelease_VIP
+		 *
+		 * @var PostRelease_VIP
+		 */
+		private static $instance;
 
-if (!function_exists('wpcom_is_vip')) {
-	register_activation_hook( __FILE__, 'postrelease_notify_activate' );
-	register_deactivation_hook( __FILE__, 'postrelease_notify_deactivate' );	
-}
+		/**
+		 * Post type
+		 *
+		 * @var string
+		 */
+		public $post_type = 'pr_sponsored_post';
 
-/**
- * Appends the PostRelease javascript to header 
- */
-function postrelease_wp_enqueue_scripts() {
-	//if plugin is activated and we are not in an admin page
-	if ( 1 == get_option( 'prx_plugin_activated', 0 ) && ! is_admin() ) {
-	    wp_register_script('postrelease', PRX_JAVASCRIPT_URL);
-	    wp_enqueue_script('postrelease');
-	}
-}
+		/**
+		 * Plugin version
+		 *
+		 * @var string
+		 */
+		public $plugin_version = '1.3';
 
-function postrelease_init() {
-	$args = array('public' => false || PRX_DEV,
-				  'publicly_queryable' => true,
-	              'label' => 'Sponsored Post',
-	    		  'exclude_from_search' => true,
-	    		  'can_export' => false,	 
-	    		  'supports' => array( 'title', 'editor', 'author', 'thumbnail', 'excerpt' )
-	);
-	register_post_type( PRX_CUSTOM_TYPE, $args );
-}
+		/**
+		 * DB Version
+		 *
+		 * @var string
+		 */
+		public $db_version = 1;
 
-/**
- * Function when plugin is activated.
- * In WP VIP, the activate hook is not supported.
- * The plugin is activated when the user goes to the dashboard and
- * adds his publication to the PostRelease network. 
- */
-function postrelease_activate() {
-	if ( ! function_exists( 'wpcom_is_vip' ) ) {
-		flush_rewrite_rules(); //not vip
-	} else {
-		do_action( 'postrelease_activate' ); //vip
-	}
-}
+		/**
+		 * In development mode?
+		 *
+		 * @var string
+		 */
+		public $is_dev = true;
 
-/**
- * Reset changes caused by the plugin 
- */
-function postrelease_deactivate() {
-	//delete all sponsored posts
-	$sponsored_posts_array = get_pages(array('post_type' => PRX_CUSTOM_TYPE));
-	foreach( $sponsored_posts_array as $sponsored_post ) {
-		wp_delete_post( $sponsored_post->ID, true);
-	}
+		/**
+		 * URL of postrelease server
+		 *
+		 * @var string
+		 */
+		public $postrelease_server = 'http://www.postrelease.com';
 
-	delete_option('prx_template_post_id');
-	delete_option('prx_plugin_activated');
-	delete_option('prx_plugin_key');
-	delete_option('prx_database_version');
-}
+		/**
+		 * URL of postrelease js file
+		 *
+		 * @var string
+		 */
+		public $postrelease_js_url = 'http://a.postrelease.com/serve/load.js?async=true';
 
-/**
- * Check if ad full page is created and OK
- * If not, recreate it 
- * 
- * Returns false if the page had to be created
- * That means that either:
- * - the plugin was just installed
- * - the template page was corrupted or deleted somehow and we need to create a new one
- */
-function postrelease_check_full_page() {
-	$page_id = get_option('prx_template_post_id', false);
-	if( ! $page_id ) {
-		postrelease_create_page();
-		return false;
-	}
-	
-	$page = get_page($page_id);
-	
-	if($page == null || 
-	   strcmp($page->post_status,'publish') != 0 || 
-	   strstr($page->post_name, 'postrelease') == false ||
-	   strcmp($page->post_type, PRX_CUSTOM_TYPE) != 0 ||	   
-	   strcmp($page->post_title,'<span class="prx_title"></span>') != 0 || 
-	   strcmp($page->post_content,'<span class="prx_body"></span>') != 0
-	   ) 
-	{
-		postrelease_create_page();
-		return false;
-	}
-	
-	return true;
-}
+		/**
+		 * Initialize the class.
+		 */
+		public function __construct() {}
 
-/**
- * Allow additional parameters in the URL
- * @param unknown_type $vars
- */
-function postrelease_add_query_vars($vars) {
-	$vars[] = "prx_t";
-	$vars[] = "prx_rk";
-	$vars[] = "prx_ro";
-	$vars[] = "prx";
-	return $vars;
-}
+		/**
+		 * Return an instance of this class.
+		 *
+		 * @return object
+		 */
+		public static function get_instance() {
+			if ( is_null( self::$instance ) ) {
+				self::$instance = new self();
+				self::$instance->setup();
+			}
+			return self::$instance;
+		}
 
-/**
- * Create the ad template post 
- */
-function postrelease_create_page() {
-    $current_user = wp_get_current_user();
-    
-	$template_post = array(
-	    		'post_title' => '<span class="prx_title"></span>',
-	    		'post_content' => '<span class="prx_body"></span>',
-	    		'post_type' => PRX_CUSTOM_TYPE,
-	    		'post_status' => 'publish',
-	    		'post_author' => $current_user->ID,
-	    		'post_name' => 'postrelease',
-				'post_date' => "1960-01-01 00:0:00",
-				'post_date_gmt' => "1960-01-01 00:00:00",
-	    		'comment_status' => 'closed',
-				'ping_status' => 'closed',
-    		);
+		/**
+		 * Setup actions and filters, etc.
+		 *
+		 * @return void
+		 */
+		public function setup() {
+			$this->postrelease_server = trailingslashit( $this->postrelease_server );
 
-    $template_post_id = wp_insert_post($template_post);
+			// Actions
+			add_action( 'init', [ $this, 'postrelease_init' ] );
+			add_action( 'init', [ $this, 'postrelease_handle_enable_request' ] );
+			add_action( 'init', [ $this, 'postrelease_handle_signup_requests' ] );
+			add_action( 'admin_init', [ $this, 'postrelease_admin_init' ] );
+			add_action( 'wp_enqueue_scripts', [ $this, 'postrelease_wp_enqueue_scripts' ], 1 );
+			add_action( 'admin_menu', [ $this, 'postrelease_create_menu' ] ); // create custom plugin settings menu
+			add_action( 'template_redirect', [ $this, 'postrelease_template_redirect' ] );
 
-    //save in wordpress db so we can remove that when deactivating plugin
-    update_option('prx_template_post_id', $template_post_id);
-}
+			// Filters
+			add_filter( 'the_author', [ $this, 'postrelease_the_author' ] );
+			add_filter( 'query_vars', [ $this, 'postrelease_add_query_vars' ] );
+			add_filter( 'author_link', [ $this, 'postrelease_author_link' ], 100, 2 );
+			add_filter( 'get_the_date', [ $this, 'postrelease_get_the_date_time' ], 10, 2 );
+			add_filter( 'get_the_time', [ $this, 'postrelease_get_the_date_time' ], 10, 2 );
 
+			if ( ! function_exists( 'wpcom_is_vip' ) ) {
+				register_activation_hook( __FILE__, [ $this, 'postrelease_notify_activate' ] );
+				register_deactivation_hook( __FILE__, [ $this, 'postrelease_notify_deactivate' ] );
+			}
 
-function postrelease_template_redirect() {
-	global $wp_query;
+		}
 
-	// functions that don't require security check
-	if(isset($wp_query->query_vars['prx'])) { //prx is a URL parameter
-		$function = $wp_query->query_vars['prx'];	
-		
-		if ($function == 'ad') {	// redirect to full ad page		
-			if(get_option('prx_plugin_activated', 0) == 1) {
+		/**
+		 * Appends the PostRelease javascript to header
+		 *
+		 * @return void
+		 */
+		public function postrelease_wp_enqueue_scripts() {
+			wp_enqueue_script( 'postrelease', $this->postrelease_js_url, [], null, false );
+		}
 
-				//redirect to template page
-				$template_post_id = get_option('prx_template_post_id', 1);
+		/**
+		 * Register postrelease post type
+		 *
+		 * @return void
+		 */
+		public function postrelease_init() {
+			$args = [
+				'public' => false || $this->is_dev,
+				'publicly_queryable' => true,
+				'label' => 'Sponsored Post',
+				'exclude_from_search' => true,
+				'can_export' => false,
+				'supports' => [
+					'title',
+					'editor',
+					'author',
+					'thumbnail',
+					'excerpt',
+				],
+			];
+			register_post_type( $this->post_type, $args );
+		}
 
-				if ( ! $template_post_id )
-					return;
+		/**
+		 * Function when plugin is activated.
+		 * In WP VIP, the activate hook is not supported.
+		 * The plugin is activated when the user goes to the dashboard and
+		 * adds his publication to the PostRelease network.
+		 *
+		 * @return void
+		 */
+		public function postrelease_activate() {
+			if ( ! function_exists( 'wpcom_is_vip' ) ) {
+				flush_rewrite_rules();
+			} else {
+				do_action( 'postrelease_activate' );
+			}
+		}
 
-				$template_post_url = get_permalink($template_post_id);
+		/**
+		 * Reset changes caused by the plugin upon deactivation
+		 *
+		 * @return void
+		 */
+		public function postrelease_deactivate() {
+			// delete all sponsored posts
+			$sponsored_posts_array = get_pages( [ 'post_type' => $this->post_type ] );
+			if ( ! empty( $sponsored_posts_array ) ) {
+				foreach ( $sponsored_posts_array as $sponsored_post ) {
+					wp_delete_post( $sponsored_post->ID, true );
+				}
+			}
+			delete_option( 'prx_template_post_id' );
+			delete_option( 'prx_plugin_activated' );
+			delete_option( 'prx_plugin_key' );
+			delete_option( 'prx_database_version' );
+		}
 
-				$query_struct = array();
-				parse_str($_SERVER['QUERY_STRING'], $query_struct);
-				$template_post_url = add_query_arg( $query_struct, $template_post_url ); //keeping URL parameters when we redirect (prx_t and prx_rk need to stay in the URL)				
-				$template_post_url = add_query_arg( 'prx', 'page', $template_post_url ); //prx=page so that we do not get redirected anymore
-				wp_redirect( $template_post_url );
-				
+		/**
+		 * Check if ad full page is created and OK
+		 * If not, recreate it
+		 *
+		 * Returns false if the page had to be created
+		 * That means that either:
+		 * - the plugin was just installed
+		 * - the template page was corrupted or deleted somehow and we need to create a new one
+		 *
+		 * @return boolean
+		 */
+		public function postrelease_check_full_page() {
+			$page_id = get_option( 'prx_template_post_id', false );
+			if ( false === $page_id ) {
+				$this->postrelease_create_page();
+				return false;
+			}
+
+			$page = get_page( intval( $page_id ) );
+
+			if (
+				is_null( $page )
+				|| 0 !== strcmp( $page->post_status,'publish' )
+				|| false === strstr( $page->post_name, 'postrelease' )
+				|| 0 !== strcmp( $page->post_type, $this->post_type )
+				|| 0 !== strcmp( $page->post_title,'<span class="prx_title"></span>' )
+				|| 0 !== strcmp( $page->post_content,'<span class="prx_body"></span>' )
+			) {
+				$this->postrelease_create_page();
+				return false;
+			}
+			return true;
+		}
+
+		/**
+		 * Allow additional parameters in the URL
+		 *
+		 * @param array $vars
+		 * @return array modified vars
+		 */
+		public function postrelease_add_query_vars( $vars ) {
+			$vars[] = "prx_t";
+			$vars[] = "prx_rk";
+			$vars[] = "prx_ro";
+			$vars[] = "prx";
+			return $vars;
+		}
+
+		/**
+		 * Create the ad template post
+		 *
+		 * @return void
+		 */
+		public function postrelease_create_page() {
+			$current_user = wp_get_current_user();
+
+			$template_post = [
+				'post_title'     => '<span class="prx_title"></span>',
+				'post_content'   => '<span class="prx_body"></span>',
+				'post_type'      => $this->post_type,
+				'post_status'    => 'publish',
+				'post_author'    => $current_user->ID,
+				'post_name'      => 'postrelease',
+				'post_date'      => "1960-01-01 00:0:00",
+				'post_date_gmt'  => "1960-01-01 00:00:00",
+				'comment_status' => 'closed',
+				'ping_status'    => 'closed',
+			];
+
+			$template_post_id = wp_insert_post( $template_post );
+
+			// save in wordpress db so we can remove that when deactivating plugin
+			update_option( 'prx_template_post_id', $template_post_id );
+		}
+
+		/**
+		 * Template redirect
+		 *
+		 * @return void
+		 */
+		public function postrelease_template_redirect() {
+			global $wp_query;
+
+			// functions that don't require security check
+			if ( isset( $wp_query->query_vars['prx'] ) ) { // prx is a URL parameter
+				$function = sanitize_text_field( $wp_query->query_vars['prx'] );
+				// redirect to full ad page
+				if ( ( 'ad' === $function ) && ( 1 === intval( get_option( 'prx_plugin_activated', 0 ) ) ) ) {
+					//redirect to template page
+					$template_post_id = intval( get_option( 'prx_template_post_id', 1 ) );
+
+					if ( ! $template_post_id ) {
+						return;
+					}
+
+					if ( false !== $template_post_url = get_permalink( $template_post_id ) ) {
+						$query_struct = [];
+						parse_str( $_SERVER['QUERY_STRING'], $query_struct );
+						$query_struct = rawurlencode( $query_struct );
+						// keeping URL parameters when we redirect (prx_t and prx_rk need to stay in the URL)
+						$template_post_url = add_query_arg( $query_struct, $template_post_url );
+						// prx=page so that we do not get redirected anymore
+						$template_post_url = add_query_arg( 'prx', 'page', $template_post_url );
+						wp_safe_redirect( esc_url( $template_post_url ) );
+						exit;
+					}
+				}
+			}
+		}
+
+		/**
+		 * Security check - validate key
+		 *
+		 * @param string $key security MD5 encoded
+		 * @return boolean
+		 */
+		public function postrelease_is_key_valid( $key ) {
+			if ( false !== get_option( 'prx_plugin_key', false ) ) {
+				$md5_key = md5( get_option( 'prx_plugin_key' ) );
+				if ( 0 === strcmp( $md5_key, $key ) ) {
+					return true;
+				}
+				return false;
+			}
+			return false;
+		}
+
+		/**
+		 * Authenticate if IP is coming from localhost or from a PostRelease server
+		 *
+		 * @return boolean
+		 */
+		public function postrelease_authenticate_IP() {
+			$ip = sanitize_text_field( $_SERVER['REMOTE_ADDR'] );
+			if ( 0 === strlen( $ip ) ) {
+				$ip = getenv( "REMOTE_ADDR" );
+			} else {
+				$ip = trim( $ip );
+			}
+			$args = [
+				'method' => 'GET',
+				'timeout' => 2,
+				'user-agent' => 'Wordpress_plugin',
+				'sslverify' => true,
+			];
+			$response = wp_safe_remote_get( trailingslashit( $this->postrelease_server ) . 'plugins/Api/AuthenticateIP?ip=' . $ip, $args );
+			if ( is_wp_error( $response ) ) {
+				return false;
+			}
+			$body = wp_remote_retrieve_body( $response );
+			$obj = json_decode( $body );
+			return isset( $obj->{'result'} ) && 1 == $obj->{'result'};
+		}
+
+		/**
+		 * Creates an entry in the admin menu for
+		 * Post Release settings
+		 */
+		public function postrelease_create_menu() {
+			// Add PostRelease menu item under the "Settings" top-level menu
+			add_submenu_page( 'options-general.php', __( 'PostRelease Dashboard', 'lin' ), __( 'PostRelease', 'lin' ), 'manage_options', 'postrelease', 'postrelease_settings_page' );
+		}
+
+		/**
+		 * Opens iframe to http://www.postrelease.com
+		 * User can check his PostRelease publication dashboard
+		 * and Edit the template of his publication.
+		 * All of this is done inside the iframe.
+		 *
+		 * @return void, outputs html
+		 */
+		public function postrelease_settings_page() {
+			$dashboard_path = $this->postrelease_server . 'wpplugin/Index/?PublicationUrl=' . urlencode( home_url( '/' , 'http' ) ) . '&vip=1';
+			echo '<center><iframe src="' . esc_url( $dashboard_path ) . '" style="margin: 0 auto;" width="700px" height="900px" frameborder="0" scrolling="no"></iframe></center>';
+		}
+
+		/**
+		 * Check if needs to run upgrade routine
+		 *
+		 * @return void
+		 */
+		public function postrelease_admin_init() {
+			$current_db_version = get_option( 'prx_database_version', 0 );
+			if ( $current_db_version < $this->db_version ) {
+				$this->postrelease_upgrade( $this->db_version );
+				update_option( 'prx_database_version', $this->db_version );
+			}
+		}
+
+		/**
+		 * Upgrade routine
+		 *
+		 * @return void
+		 */
+		public function postrelease_upgrade( $current_db_version ) {
+			// create template post
+			if ( 1 >= $current_db_version ) {
+				$this->postrelease_check_full_page();
+			}
+		}
+
+		/**
+		 * Handle signup requests
+		 *
+		 * @return void
+		 */
+		public function postrelease_handle_signup_requests() {
+			if ( isset( $_REQUEST['prx'] ) ) {
+				$function = strtolower( sanitize_text_field( $_REQUEST['prx'] ) );
+
+				if ( 'prx_generate_key' === $function ) {
+					$this->postrelease_generate_security_key();
+					exit;
+				}
+
+				// security check, block any requests that do not have the security key
+				$security_check_ok = false || $this->is_dev;
+
+				if ( isset( $_REQUEST['id'] ) ) { //there is a key saved here
+					$key_url = sanitize_text_field( $_REQUEST['id'] );
+					$security_check_ok = $this->postrelease_is_key_valid( $key_url );
+				}
+
+				// these functions require security check to be called
+				if ( $security_check_ok && $this->postrelease_authenticate_IP() ) {
+					// enable plugin during sign up process
+					if ( 'enable' === $function ) {
+						if ( isset( $_REQUEST['status'] ) ) {
+							$this->postrelease_enable_plugin( sanitize_text_field( $_REQUEST['status'] ) );
+						 // get latest posts so that our server can index blog's content
+						} else if ( 'getposts' === $function ) {
+							$this->postrelease_get_posts_xml_for_indexing();
+						} else if ( 'status' === $function ) {
+							$this->postrelease_get_status();
+						} else if ( 'check' === $function ) {
+							$this->postrelease_get_check();
+						}
+						exit;
+					}
+				}
+			}
+		}
+
+		/**
+		 * Handle enable request/send success response
+		 *
+		 * @return void
+		 */
+		public function postrelease_handle_enable_request() {
+			if (
+				isset( $_GET['do'] )
+				&& 'update' == $_GET['do']
+				&& isset( $_GET['postrelease_enable'] )
+				&& '1' == $_GET['postrelease_enable']
+			) {
+				$this->postrelease_send_success_response();
 				exit;
 			}
 		}
-	}	
-}
 
-/**
- * Security check - validate key 
- * @param string $key security MD5 encoded
- */
-function postrelease_is_key_valid($key) {
-	if( false != get_option('prx_plugin_key', false) ) { //there is a key saved here
-		$md5_key = md5(get_option('prx_plugin_key'));
-		if(strcmp($md5_key,$key) === 0) {
-			return true;
-		}
-	}
-	
-	return false;
-}
+		/**
+		 * This code returns XML that follows the schema
+		 * specified in PostRelease API documentation.
+		 * This XML will be used to hydrate our indexing system that is necessary to
+		 * suggest what are the best publications for an ad.
+		 *
+		 * @return void, outputs XML
+		 */
+		public function postrelease_get_posts_xml_for_indexing() {
+			// by default return 200 posts
+			$default_number_posts = 200;
 
- /**
-  * Get client's IP
-  * PostRelease will use this for geotargetting
-  */
- function postrelease_get_client_IP() { 
-    return $_SERVER['REMOTE_ADDR'];
-}
+			// sanitizing num URL parameter
+			$number_posts = isset( $_REQUEST['num'] ) ? intval( $_REQUEST['num'] ) : 0;
 
-/**
- * Authenticate if IP is coming from localhost or from a PostRelease server 
- */
-function postrelease_authenticate_IP(){
-	$ip = postrelease_get_client_IP();
-	if (strlen($ip) == 0){
-		$ip = getenv("REMOTE_ADDR");
-	} else {
-		$ip = trim($ip);
-	}
-
-	$args = array(
-		'method' => 'GET',
-		'timeout' => 2,
-		'user-agent' => 'Wordpress_plugin',
-		'sslverify' => true,
-	);
-	$response = wp_remote_get( PRX_POSTRELEASE_SERVER.'/plugins/Api/AuthenticateIP?ip=' . $ip, $args );
-	if ( is_wp_error( $response ) ) {
-		return false;		
-	} else {
-		$body = wp_remote_retrieve_body($response);		
-		$obj = json_decode($body);
-		return isset( $obj->{'result'} ) && 1 == $obj->{'result'};
-	}
-}
-
-/**
- * Creates an entry in the admin menu for
- * Post Release settings 
- */
-function postrelease_create_menu() {
-	// Add PostRelease menu item under the "Settings" top-level menu
-	$page = add_submenu_page('options-general.php','PostRelease Dashboard', 'PostRelease', 'manage_options', 'postrelease', 'postrelease_settings_page');
-}
-
-/**
- * Opens iframe to http://www.postrelease.com
- * User can check his PostRelease publication dashboard
- * and Edit the template of his publication.
- * All of this is done inside the iframe.
- */
-function postrelease_settings_page() {
-	$dashboard_path = PRX_POSTRELEASE_SERVER . '/wpplugin/Index/?PublicationUrl=' . urlencode( home_url( '/' , 'http') ) . '&vip=1';
-	echo '<center><iframe src="'. esc_url( $dashboard_path ) .'" style="margin: 0 auto;" width="700px" height="900px" frameborder="0" scrolling="no"></iframe></center>';
-}
-
-/**
- * Check if needs to run upgrade routine 
- */
-function postrelease_admin_init() {
-	$current_db_version = get_option('prx_database_version', 0);
-	if ($current_db_version < PRX_DB_VERSION) {
-		postrelease_upgrade(PRX_DB_VERSION);
-		update_option('prx_database_version', PRX_DB_VERSION);
-	}
-}
-
-/**
- * Upgrade routine
- */
-function postrelease_upgrade($current_db_version) {
-	//create template post
-	if ($current_db_version <= 1) {
-		postrelease_check_full_page();
-	}
-	
-	//for any future modifications in the database we can add more if()'s here...
-}
-
-function postrelease_handle_signup_requests() {
-	if(isset($_REQUEST['prx'])) { //prx is a URL parameter
-		$function = $_REQUEST['prx'];	
-
-		if($function == 'prx_generate_key') { 
-			postrelease_generate_security_key();
-			exit;
-		} 
-		
-		//security check, block any requests that do not have the security key
-		$security_check_ok = false || PRX_DEV;
-
-		if(isset($_REQUEST['id'])) { //there is a key saved here
-			$key_url = sanitize_text_field( $_REQUEST['id'] );
-			$security_check_ok = postrelease_is_key_valid( $key_url );
-		}		
-
-		// these functions require security check to be called
-		if( $security_check_ok && postrelease_authenticate_IP() ) {
-
-			if($function == 'enable') { // enable plugin during sign up process
-				if ( isset( $_REQUEST['status'] ) )
-					postrelease_enable_plugin( sanitize_text_field( $_REQUEST['status'] ) );
-			} else if ($function == 'getposts') { //get latest posts so that our server can index blog's content
-				postrelease_get_posts_xml_for_indexing();
-			} else if($function == 'status') {
-				postrelease_get_status();
-			} else if ($function == 'check') {
-				postrelease_get_check();
+			if ( 0 > $number_posts || 200 < $number_posts ) {
+				$number_posts = $default_number_posts;
 			}
-			exit;
-		}
-	}
-}
 
-function postrelease_handle_enable_request() {
-	if( isset( $_GET['do'] ) && 'update' == $_GET['do']
-	   && isset( $_GET['postrelease_enable'] ) && '1' == $_GET['postrelease_enable'] ) {
-		postrelease_send_success_response();
-		exit;
-	}
-}
+			$args = [
+				'posts_per_page' => $number_posts,
+				'ignore_sticky_posts' => true,
+				'no_found_rows' => true,
+			];
+			$posts_for_xml = new WP_Query( $args );
 
-/**
- * This code returns a XML that follows the schema
- * specified in PostRelease API documentation.
- * This XML will be used to hydrate our indexing system that is necessary to
- * suggest what are the best publications for an ad.
- */
-function postrelease_get_posts_xml_for_indexing() {
-	$default_number_posts = 200; //by default return 200 posts
-		
-	//sanitizing num URL parameter
-	$number_posts = isset( $_REQUEST['num'] ) ? intval( $_REQUEST['num'] ) : 0;
-	
-	if( 0 > $number_posts || 200 < $number_posts ) {
-		$number_posts = $default_number_posts;
-	}
-		
-	$args = array( 'numberposts' => $number_posts );
-	$posts = get_posts( $args );
-		
-	$xml = '<?xml version="1.0" encoding="UTF-8" ?>';
-	$xml .= "<articles>";
-	foreach($posts as $p) {
-		$xml .= "<article>";
-		$xml .= "<id>$p->ID</id>";
-		$xml .= "<link><![CDATA[$p->guid]]></link>";
-		$xml .= "<title><![CDATA[$p->post_title]]></title>";
-		$xml .= "<content><![CDATA[$p->post_content]]></content>";
-		$xml .= "</article>";
-	}
-	$xml .= "</articles>";
-	echo ($xml);
-		
-}
-
-/**
- * Does nothing and just returns a result=1 json
- * This is called by sign up process (always returns 1)
- * The plugin will be enabled with the prx=enable call (function postrelease_enable_plugin)
- * We need to maintain this call because it's part of server sign up process
- */		
-function postrelease_send_success_response() {
-	if (preg_match('/\W/', $_REQUEST['callback'])) {
-		header('HTTP/1.1 400 Bad Request');
-		exit();
-	}
-	header('Cache-Control: no-cache, must-revalidate');
-	header('Content-type: application/javascript; charset=utf-8');
-	$data = array('result' => 1);
-	print sprintf('%s(%s);', $_REQUEST['callback'], json_encode($data));
-}
-
-/**
- * Generates a random security key that will be saved both
- * on the blog side as well as on the PostRelease side
- * This key will be necessary to make calls to the plugin during the sign up
- * process and later for indexing purposes
- */
-function postrelease_generate_security_key() {
-	//if key already exists
-	if( false != get_option('prx_plugin_key', false) ) { 
-		print('FAIL: key already exists');
-		return;
-	}
-
-	if( postrelease_authenticate_IP() ) {
-		$key = wp_generate_password( 10, false, false );
-		update_option('prx_plugin_key', $key);
-		$data['Key'] = $key;
-		$output = json_encode($data);
-		print($output);
-	} else {
-		print('FAIL: IP authentication error');
-	}
-}
-
-/**
- * Returns information about the blog
- * This is called by the PostRelease server during 
- * sign up 
- */
-function postrelease_get_status() {
-	$response = array();
-	$response['PublicationTitle'] = postrelease_get_blog_name();
-	$response['Enabled'] = get_option('prx_plugin_activated');
-	$response['PlatformVersion'] = get_bloginfo('version');
-	$response['PluginVersion'] = PRX_WP_PLUGIN_VERSION.'.vip';
-	$output = json_encode($response);
-	print($output);
-}
-
-/**
- * Returns detailed information about the blog 
- */
-function postrelease_get_check() {
-	$response = array();
-	$response['plugin_activated'] = get_option('prx_plugin_activated');
-	$response['site_url'] = site_url();
-	$response['plugin_version'] = PRX_WP_PLUGIN_VERSION.'.vip';
-	$response['postrelease_server'] = PRX_POSTRELEASE_SERVER;
-	$response['javascript_url'] = PRX_JAVASCRIPT_URL;
-	$response['db_version'] = PRX_DB_VERSION;
-	$response['php_version'] = phpversion();
-	$response['wordpress_version'] = get_bloginfo('version');
-	$response['blog_title'] = postrelease_get_blog_name();
-	$response['template_post_id'] = get_option('prx_template_post_id', '-1');
-	$response['prx_dev'] = PRX_DEV;
-	$output = json_encode($response);
-	print($output);
-}
-
-/**
- * Enable or Disable the plugin
- * This basically updates the WP option prx_plugin_activated
- * This function is called by the PostRelease server during 
- * sign up
- */
-function postrelease_enable_plugin( $enable ) {
-	$enable = sanitize_text_field( $enable );
-	$data['result'] = 0;
-
-	if( $enable == '1' || $enable == '0' ) {
-		//plugin activated changed
-		if( get_option('prx_plugin_activated') != (int) $enable ) {
-			if($enable == '0') {
-				postrelease_deactivate();
-			} else if($enable == '1') {
-				postrelease_activate();
+			if ( $posts_for_xml->have_posts() ) {
+				$xml = '<?xml version="1.0" encoding="UTF-8" ?>';
+				$xml .= '<articles>';
+				while ( $posts_for_xml->have_posts() ) : $posts_for_xml->the_post();
+					$xml .= '<article>';
+					$xml .= '<id>' . intval( get_the_ID() ) . '</id>';
+					$xml .= '<link><![CDATA[' . esc_url( get_permalink() ) . ']]></link>';
+					$xml .= '<title><![CDATA[' . wp_kses( get_the_title(), [] ) . ']]></title>';
+					$xml .= '<content><![CDATA[' . wp_kses_post( get_the_content() ) . ']]></content>';
+					$xml .= '</article>';
+				endwhile;
+				$xml .= '</articles>';
+				echo $xml;
 			}
 		}
 
-		update_option( 'prx_plugin_activated', (int) $enable );
-		$data['result'] = 1;
+		/**
+		 * Does nothing and just returns a result=1 json
+		 * This is called by sign up process (always returns 1)
+		 * The plugin will be enabled with the prx=enable call (function postrelease_enable_plugin)
+		 * We need to maintain this call because it's part of server sign up process
+		 *
+		 * @return void, outputs html
+		 */
+		public function postrelease_send_success_response() {
+			if ( preg_match( '/\W/', $_REQUEST['callback'] ) ) {
+				header( 'HTTP/1.1 400 Bad Request' );
+				exit;
+			}
+			header( 'Cache-Control: no-cache, must-revalidate' );
+			header( 'Content-type: application/javascript; charset=utf-8' );
+			$data = [ 'result' => 1 ];
+			echo esc_html( sprintf( '%s(%s);', $_REQUEST['callback'], wp_json_encode( $data ) ) );
+		}
+
+		/**
+		 * Generates a random security key that will be saved both
+		 * on the blog side as well as on the PostRelease side
+		 * This key will be necessary to make calls to the plugin during the sign up
+		 * process and later for indexing purposes
+		 *
+		 * @return void
+		 */
+		public function postrelease_generate_security_key() {
+			// if key already exists
+			if ( false !== get_option( 'prx_plugin_key', false ) ) {
+				echo 'FAIL: key already exists';
+				return;
+			}
+
+			if ( postrelease_authenticate_IP() ) {
+				$key = wp_generate_password( 10, false, false );
+				update_option( 'prx_plugin_key', $key );
+				$data['Key'] = $key;
+				$output = wp_json_encode( $data );
+				echo $output;
+			} else {
+				echo 'FAIL: IP authentication error';
+			}
+		}
+
+		/**
+		 * Returns information about the blog
+		 * This is called by the PostRelease server during
+		 * sign up
+		 *
+		 * @return void
+		 */
+		public function postrelease_get_status() {
+			$response = [];
+			$response['PublicationTitle'] = postrelease_get_blog_name();
+			$response['Enabled'] = get_option( 'prx_plugin_activated' );
+			$response['PlatformVersion'] = get_bloginfo( 'version' );
+			$response['PluginVersion'] = PRX_WP_PLUGIN_VERSION . '.vip';
+			$output = wp_json_encode( $response );
+			echo $output;
+		}
+
+		/**
+		 * Returns detailed information about the blog
+		 *
+		 * @return void, outputs JSON
+		 */
+		public function postrelease_get_check() {
+			$response = [];
+			$response['plugin_activated'] = get_option( 'prx_plugin_activated' );
+			$response['site_url'] = site_url();
+			$response['plugin_version'] = PRX_WP_PLUGIN_VERSION . '.vip';
+			$response['postrelease_server'] = PRX_POSTRELEASE_SERVER;
+			$response['javascript_url'] = PRX_JAVASCRIPT_URL;
+			$response['db_version'] = PRX_DB_VERSION;
+			$response['php_version'] = phpversion();
+			$response['wordpress_version'] = get_bloginfo( 'version' );
+			$response['blog_title'] = postrelease_get_blog_name();
+			$response['template_post_id'] = get_option( 'prx_template_post_id', '-1' );
+			$response['prx_dev'] = PRX_DEV;
+			$output = wp_json_encode( $response );
+			echo $output;
+		}
+
+		/**
+		 * Enable or Disable the plugin
+		 * This basically updates the WP option prx_plugin_activated
+		 * This function is called by the PostRelease server during
+		 * sign up
+		 *
+		 * @return void, outputs JSON
+		 */
+		public function postrelease_enable_plugin( $enable ) {
+			$enable = intval( $enable );
+			$data['result'] = 0;
+
+			if ( 1 === $enable || 0 === $enable ) {
+				// plugin activated changed
+				if ( $enable !== intval( get_option( 'prx_plugin_activated') ) ) {
+					if ( 0 === $enable ) {
+						$this->postrelease_deactivate();
+					} else if ( 1 === $enable ) {
+						$this->postrelease_activate();
+					}
+				}
+				update_option( 'prx_plugin_activated', (int) $enable );
+				$data['result'] = 1;
+			}
+			echo wp_json_encode( $data );
+		}
+
+		/**
+		 * Return the blog name.
+		 * If it's not set, return the blog URL.
+		 */
+		public function postrelease_get_blog_name() {
+			if ( 0 === strlen( trim( get_bloginfo( 'name') ) ) ) {
+				return site_url();
+			} else {
+				return get_bloginfo( 'name' );
+			}
+		}
+
+		/**
+		 * Change author display name to "Promoted" in secondary impression
+		 */
+		public function postrelease_the_author( $author ) {
+			global $post;
+			$template_post_id = get_option( 'prx_template_post_id' );
+			if ( ! empty( $post->ID ) && ( $post->ID === intval( get_option( 'prx_template_post_id', -1 ) ) ) ) {
+				$author = 'Promoted';
+			}
+			return $author;
+		}
+
+		/**
+		 * Change author link to blog homepage URL in secondary impression
+		 */
+		public function postrelease_author_link( $link, $author_id ) {
+			global $post;
+			if ( ! empty( $post->ID ) && ( $post->ID === intval( get_option( 'prx_template_post_id', -1 ) ) ) ) {
+				$link = esc_url( get_home_url( $post->ID ) );
+			}
+			return $link;
+		}
+
+		/**
+		 * Change date to today's date in secondary impression
+		 * We do not want to display that fake date of 1/1/1960
+		 *
+		 * @param  string $date_time the date/time
+		 * @param  string $format    the date format
+		 * @return string            formatted date
+		 */
+		public function postrelease_get_the_date_time( $date_time, $format ) {
+			global $post;
+			if ( $post->ID == get_option( 'prx_template_post_id', -1 ) ) {
+				$date_time = date( $d, time() );
+			}
+			return $date_time;
+		}
+
+		/**
+		 * Notify the PostRelease server that the plugin in this publication was activated
+		 *
+		 * @return boolean
+		 */
+		public function postrelease_notify_activate() {
+			// notify PostRelease team that plugin was activated
+			$args = [
+				'method' => 'POST',
+				'timeout' => 2,
+				'user-agent' => 'Wordpress_plugin',
+				'sslverify' => true,
+			];
+			$url = rawurlencode( $this->postrelease_server . 'plugins/Api/PluginActivated?url=' . site_url() );
+			return is_wp_error( wp_safe_remote_post( $url, $args ) );
+		}
+
+		/**
+		 * Notify the PostRelease server that the plugin in this publication was deactivated
+		 *
+		 * @return boolean
+		 */
+		public function postrelease_notify_deactivate() {
+			// notify PostRelease team that plugin was deactivated
+			$args = [
+				'method' => 'POST',
+				'timeout' => 2,
+				'user-agent' => 'Wordpress_plugin',
+				'sslverify' => true,
+			];
+			$url = rawurlencode( $this->postrelease_server . 'plugins/Api/PluginDeactivated?url=' . site_url() );
+			return is_wp_error( wp_safe_remote_post( $url, $args ) );
+		}
+
 	}
-	print json_encode($data);
-}
 
-/**
- * Return the blog name.
- * If it's not set, return the blog URL. 
- */
-function postrelease_get_blog_name() {
-	if(strlen(trim(get_bloginfo('name'))) == 0) {
-		return site_url();
-	} else {
-		return get_bloginfo('name');	
-	}
-}
+	PostRelease_VIP::get_instance();
 
-/**
- * Change author display name to "Promoted" in secondary impression
- */
-function postrelease_the_author($author) {
-	global $post;
-	$template_post_id = get_option('prx_template_post_id');
-	if(isset($post) && $post->ID == get_option('prx_template_post_id', -1)) {
-		$author = 'Promoted';
-	}
-	return $author;
-}
-
-/**
- * Change author display name to "Promoted" in secondary impression 
- */
-function postrelease_the_author_display_name($author) {
-	global $post;
-	$template_post_id = get_option('prx_template_post_id');
-	if(isset($post) && $post->ID == get_option('prx_template_post_id', -1)) {
-		$author = 'Promoted';
-	}
-	return $author;
-}
-
-/**
- * Change author link to blog homepage URL in secondary impression
- */
-function postrelease_author_link($link, $author_id) {
-	global $post;
-	if(isset($post) && $post->ID == get_option('prx_template_post_id', -1)) {
-		$link = home_url();
-	}
-	return $link;
-}
-
-/**
- * Change date to today's date in secondary impression
- * We do not want to display that fake date of 1/1/1960
- */
-function postrelease_get_the_date($date, $d) {	
-	global $post;
-	if($post->ID == get_option('prx_template_post_id', -1)) {
-		$date = date($d, time());		
-	}
-	return $date;
-}
-
-/**
- * Change date to today's date in secondary impression
- * We do not want to display that fake date of 1/1/1960
- */
-function postrelease_get_the_time($the_time, $d) {
-	global $post;
-	if($post->ID == get_option('prx_template_post_id', -1)) {
-		$the_time = date($d, time());	
-	}
-	return $the_time;	
-}
-
-/**
- * Notify the PostRelease server that the plugin in this publication was activated 
- */
-function postrelease_notify_activate() {
-	//notify PostRelease team that plugin was activated
-	$args = array(
-		'method' => 'POST',
-		'timeout' => 2,
-		'user-agent' => 'Wordpress_plugin',
-		'sslverify' => true,
-	);
-	$response = wp_remote_post( PRX_POSTRELEASE_SERVER . '/plugins/Api/PluginActivated?url=' . site_url(), $args );		
-}
-
-/**
- * Notify the PostRelease server that the plugin in this publication was deactivated
- */
-function postrelease_notify_deactivate() {
-	//notify PostRelease team that plugin was deactivated
-	$args = array(
-		'method' => 'POST',
-		'timeout' => 2,
-		'user-agent' => 'Wordpress_plugin',
-		'sslverify' => true,
-	);
-	$response = wp_remote_post( PRX_POSTRELEASE_SERVER . '/plugins/Api/PluginDeactivated?url=' . site_url(), $args );		
-}
+endif;

--- a/postrelease-vip.php
+++ b/postrelease-vip.php
@@ -1,20 +1,24 @@
 <?php
+
 /*
- Plugin Name: PostRelease VIP
- Plugin URI: http://www.postrelease.com
+ Plugin Name: Nativo
+ Plugin URI: https://github.com/alleyinteractive/postrelease-vip
  Description: A plugin to handle navtive ads through Nativo
  Version: 1.3
  Author: PostRelease
- Author URI: http://www.postrelease.com
+ Author URI: https://github.com/alleyinteractive/postrelease-vip
  */
-if ( ! class_exists( PostRelease_VIP ) ) :
+if ( ! class_exists( 'Nativo' ) ) {
 
-	class PostRelease_VIP {
+	/**
+	 * Nativo - A plugin to handle navtive ads through Nativo
+	 */
+	class Nativo {
 
 		/**
-		 * The one instance of PostRelease_VIP
+		 * The one instance of Nativo
 		 *
-		 * @var PostRelease_VIP
+		 * @var Nativo
 		 */
 		private static $instance;
 
@@ -51,14 +55,14 @@ if ( ! class_exists( PostRelease_VIP ) ) :
 		 *
 		 * @var string
 		 */
-		public $postrelease_server = 'http://www.postrelease.com';
+		public $server = 'http://www.postrelease.com';
 
 		/**
 		 * URL of postrelease js file
 		 *
 		 * @var string
 		 */
-		public $postrelease_js_url = 'http://a.postrelease.com/serve/load.js?async=true';
+		public $js_url = 'http://a.postrelease.com/serve/load.js?async=true';
 
 		/**
 		 * Initialize the class.
@@ -84,27 +88,25 @@ if ( ! class_exists( PostRelease_VIP ) ) :
 		 * @return void
 		 */
 		public function setup() {
-			$this->postrelease_server = trailingslashit( $this->postrelease_server );
+			$this->server = trailingslashit( $this->server );
 
-			// Actions
-			add_action( 'init', [ $this, 'postrelease_init' ] );
-			add_action( 'init', [ $this, 'postrelease_handle_enable_request' ] );
-			add_action( 'init', [ $this, 'postrelease_handle_signup_requests' ] );
-			add_action( 'admin_init', [ $this, 'postrelease_admin_init' ] );
-			add_action( 'wp_enqueue_scripts', [ $this, 'postrelease_wp_enqueue_scripts' ], 1 );
-			add_action( 'admin_menu', [ $this, 'postrelease_create_menu' ] ); // create custom plugin settings menu
-			add_action( 'template_redirect', [ $this, 'postrelease_template_redirect' ] );
+			add_action( 'init', [ $this, 'init' ] );
+			add_action( 'init', [ $this, 'handle_enable_request' ] );
+			add_action( 'init', [ $this, 'handle_signup_requests' ] );
+			add_action( 'admin_init', [ $this, 'admin_init' ] );
+			add_action( 'wp_enqueue_scripts', [ $this, 'wp_enqueue_scripts' ] );
+			add_action( 'admin_menu', [ $this, 'create_menu' ] );
+			add_action( 'template_redirect', [ $this, 'template_redirect' ] );
 
-			// Filters
-			add_filter( 'the_author', [ $this, 'postrelease_the_author' ] );
-			add_filter( 'query_vars', [ $this, 'postrelease_add_query_vars' ] );
-			add_filter( 'author_link', [ $this, 'postrelease_author_link' ], 100, 2 );
-			add_filter( 'get_the_date', [ $this, 'postrelease_get_the_date_time' ], 10, 2 );
-			add_filter( 'get_the_time', [ $this, 'postrelease_get_the_date_time' ], 10, 2 );
+			add_filter( 'the_author', [ $this, 'the_author' ] );
+			add_filter( 'query_vars', [ $this, 'add_query_vars' ] );
+			add_filter( 'author_link', [ $this, 'author_link' ], 100, 2 );
+			add_filter( 'get_the_date', [ $this, 'get_the_date_time' ], 10, 2 );
+			add_filter( 'get_the_time', [ $this, 'get_the_date_time' ], 10, 2 );
 
 			if ( ! function_exists( 'wpcom_is_vip' ) ) {
-				register_activation_hook( __FILE__, [ $this, 'postrelease_notify_activate' ] );
-				register_deactivation_hook( __FILE__, [ $this, 'postrelease_notify_deactivate' ] );
+				register_activation_hook( __FILE__, [ $this, 'notify_activate' ] );
+				register_deactivation_hook( __FILE__, [ $this, 'notify_deactivate' ] );
 			}
 
 		}
@@ -114,8 +116,8 @@ if ( ! class_exists( PostRelease_VIP ) ) :
 		 *
 		 * @return void
 		 */
-		public function postrelease_wp_enqueue_scripts() {
-			wp_enqueue_script( 'postrelease', $this->postrelease_js_url, [], null, false );
+		public function wp_enqueue_scripts() {
+			wp_enqueue_script( 'postrelease', $this->js_url, [], null, false );
 		}
 
 		/**
@@ -123,13 +125,13 @@ if ( ! class_exists( PostRelease_VIP ) ) :
 		 *
 		 * @return void
 		 */
-		public function postrelease_init() {
+		public function init() {
 			$args = [
-				'public' => false || $this->is_dev,
-				'publicly_queryable' => true,
-				'label' => 'Sponsored Post',
+				'public'              => $this->is_dev,
+				'publicly_queryable'  => true,
+				'label'               => 'Sponsored Post',
 				'exclude_from_search' => true,
-				'can_export' => false,
+				'can_export'          => false,
 				'supports' => [
 					'title',
 					'editor',
@@ -149,7 +151,7 @@ if ( ! class_exists( PostRelease_VIP ) ) :
 		 *
 		 * @return void
 		 */
-		public function postrelease_activate() {
+		public function activate() {
 			if ( ! function_exists( 'wpcom_is_vip' ) ) {
 				flush_rewrite_rules();
 			} else {
@@ -162,9 +164,9 @@ if ( ! class_exists( PostRelease_VIP ) ) :
 		 *
 		 * @return void
 		 */
-		public function postrelease_deactivate() {
-			// delete all sponsored posts
-			$sponsored_posts_array = get_pages( [ 'post_type' => $this->post_type ] );
+		public function deactivate() {
+			/* delete all sponsored posts */
+			$sponsored_posts_array = get_posts( [ 'post_type' => $this->post_type ] );
 			if ( ! empty( $sponsored_posts_array ) ) {
 				foreach ( $sponsored_posts_array as $sponsored_post ) {
 					wp_delete_post( $sponsored_post->ID, true );
@@ -187,10 +189,10 @@ if ( ! class_exists( PostRelease_VIP ) ) :
 		 *
 		 * @return boolean
 		 */
-		public function postrelease_check_full_page() {
+		public function check_full_page() {
 			$page_id = get_option( 'prx_template_post_id', false );
 			if ( false === $page_id ) {
-				$this->postrelease_create_page();
+				$this->create_page();
 				return false;
 			}
 
@@ -204,7 +206,7 @@ if ( ! class_exists( PostRelease_VIP ) ) :
 				|| 0 !== strcmp( $page->post_title,'<span class="prx_title"></span>' )
 				|| 0 !== strcmp( $page->post_content,'<span class="prx_body"></span>' )
 			) {
-				$this->postrelease_create_page();
+				$this->create_page();
 				return false;
 			}
 			return true;
@@ -213,14 +215,14 @@ if ( ! class_exists( PostRelease_VIP ) ) :
 		/**
 		 * Allow additional parameters in the URL
 		 *
-		 * @param array $vars
+		 * @param array $vars array of query vars.
 		 * @return array modified vars
 		 */
-		public function postrelease_add_query_vars( $vars ) {
-			$vars[] = "prx_t";
-			$vars[] = "prx_rk";
-			$vars[] = "prx_ro";
-			$vars[] = "prx";
+		public function add_query_vars( $vars ) {
+			$vars[] = 'prx_t';
+			$vars[] = 'prx_rk';
+			$vars[] = 'prx_ro';
+			$vars[] = 'prx';
 			return $vars;
 		}
 
@@ -229,26 +231,26 @@ if ( ! class_exists( PostRelease_VIP ) ) :
 		 *
 		 * @return void
 		 */
-		public function postrelease_create_page() {
+		public function create_page() {
 			$current_user = wp_get_current_user();
 
-			$template_post = [
+			$args = [
 				'post_title'     => '<span class="prx_title"></span>',
 				'post_content'   => '<span class="prx_body"></span>',
 				'post_type'      => $this->post_type,
 				'post_status'    => 'publish',
 				'post_author'    => $current_user->ID,
 				'post_name'      => 'postrelease',
-				'post_date'      => "1960-01-01 00:0:00",
-				'post_date_gmt'  => "1960-01-01 00:00:00",
+				'post_date'      => '1960-01-01 00:0:00',
+				'post_date_gmt'  => '1960-01-01 00:00:00',
 				'comment_status' => 'closed',
 				'ping_status'    => 'closed',
 			];
 
-			$template_post_id = wp_insert_post( $template_post );
+			$post_id = wp_insert_post( $args );
 
-			// save in wordpress db so we can remove that when deactivating plugin
-			update_option( 'prx_template_post_id', $template_post_id );
+			// save in wordpress db so we can remove that when deactivating plugin.
+			update_option( 'prx_template_post_id', $post_id );
 		}
 
 		/**
@@ -256,28 +258,29 @@ if ( ! class_exists( PostRelease_VIP ) ) :
 		 *
 		 * @return void
 		 */
-		public function postrelease_template_redirect() {
+		public function template_redirect() {
 			global $wp_query;
 
-			// functions that don't require security check
-			if ( isset( $wp_query->query_vars['prx'] ) ) { // prx is a URL parameter
+			// functions that don't require security check.
+			if ( isset( $wp_query->query_vars['prx'] ) ) {
 				$function = sanitize_text_field( $wp_query->query_vars['prx'] );
-				// redirect to full ad page
+				// redirect to full ad page.
 				if ( ( 'ad' === $function ) && ( 1 === intval( get_option( 'prx_plugin_activated', 0 ) ) ) ) {
-					//redirect to template page
+					// redirect to template page.
 					$template_post_id = intval( get_option( 'prx_template_post_id', 1 ) );
 
 					if ( ! $template_post_id ) {
 						return;
 					}
-
-					if ( false !== $template_post_url = get_permalink( $template_post_id ) ) {
+					$template_post_url = get_permalink( $template_post_id );
+					if ( false !== $template_post_url ) {
 						$query_struct = [];
-						parse_str( $_SERVER['QUERY_STRING'], $query_struct );
+						$query_string = isset( $_SERVER['QUERY_STRING'] ) ? esc_url_raw( wp_unslash( $_SERVER['QUERY_STRING'] ) ) : '';
+						parse_str( $query_string, $query_struct );
 						$query_struct = rawurlencode( $query_struct );
-						// keeping URL parameters when we redirect (prx_t and prx_rk need to stay in the URL)
+						// keeping URL parameters when we redirect (prx_t and prx_rk need to stay in the URL).
 						$template_post_url = add_query_arg( $query_struct, $template_post_url );
-						// prx=page so that we do not get redirected anymore
+						// prx=page so that we do not get redirected anymore.
 						$template_post_url = add_query_arg( 'prx', 'page', $template_post_url );
 						wp_safe_redirect( esc_url( $template_post_url ) );
 						exit;
@@ -292,13 +295,10 @@ if ( ! class_exists( PostRelease_VIP ) ) :
 		 * @param string $key security MD5 encoded
 		 * @return boolean
 		 */
-		public function postrelease_is_key_valid( $key ) {
+		public function is_key_valid( $key ) {
 			if ( false !== get_option( 'prx_plugin_key', false ) ) {
 				$md5_key = md5( get_option( 'prx_plugin_key' ) );
-				if ( 0 === strcmp( $md5_key, $key ) ) {
-					return true;
-				}
-				return false;
+				return ( 0 === strcmp( $md5_key, $key ) ) ? true : false;
 			}
 			return false;
 		}
@@ -308,35 +308,35 @@ if ( ! class_exists( PostRelease_VIP ) ) :
 		 *
 		 * @return boolean
 		 */
-		public function postrelease_authenticate_IP() {
-			$ip = sanitize_text_field( $_SERVER['REMOTE_ADDR'] );
+		public function authenticate_ip() {
+			$ip = isset( $_SERVER['REMOTE_ADDR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : '';
 			if ( 0 === strlen( $ip ) ) {
-				$ip = getenv( "REMOTE_ADDR" );
+				$ip = sanitize_text_field( getenv( 'REMOTE_ADDR' ) );
 			} else {
 				$ip = trim( $ip );
 			}
 			$args = [
-				'method' => 'GET',
-				'timeout' => 2,
+				'method'     => 'GET',
+				'timeout'    => 2,
 				'user-agent' => 'Wordpress_plugin',
-				'sslverify' => true,
+				'sslverify'  => true,
 			];
-			$response = wp_safe_remote_get( trailingslashit( $this->postrelease_server ) . 'plugins/Api/AuthenticateIP?ip=' . $ip, $args );
+			$response = wp_safe_remote_get( trailingslashit( $this->server ) . 'plugins/Api/AuthenticateIP?ip=' . $ip, $args );
 			if ( is_wp_error( $response ) ) {
 				return false;
 			}
 			$body = wp_remote_retrieve_body( $response );
 			$obj = json_decode( $body );
-			return isset( $obj->{'result'} ) && 1 == $obj->{'result'};
+			return isset( $obj->result ) && 1 == $obj->result;
 		}
 
 		/**
 		 * Creates an entry in the admin menu for
 		 * Post Release settings
 		 */
-		public function postrelease_create_menu() {
+		public function create_menu() {
 			// Add PostRelease menu item under the "Settings" top-level menu
-			add_submenu_page( 'options-general.php', __( 'PostRelease Dashboard', 'nativo' ), __( 'PostRelease', 'nativo' ), 'manage_options', 'postrelease', 'postrelease_settings_page' );
+			add_submenu_page( 'options-general.php', __( 'Nativo Dashboard', 'nativo' ), __( 'Nativo', 'nativo' ), 'manage_options', 'postrelease', [ $this, 'settings_page' ] );
 		}
 
 		/**
@@ -347,9 +347,9 @@ if ( ! class_exists( PostRelease_VIP ) ) :
 		 *
 		 * @return void, outputs html
 		 */
-		public function postrelease_settings_page() {
-			$dashboard_path = $this->postrelease_server . 'wpplugin/Index/?PublicationUrl=' . urlencode( home_url( '/' , 'http' ) ) . '&vip=1';
-			echo '<center><iframe src="' . esc_url( $dashboard_path ) . '" style="margin: 0 auto;" width="700px" height="900px" frameborder="0" scrolling="no"></iframe></center>';
+		public function settings_page() {
+			$dashboard_path = $this->server . 'wpplugin/Index/?PublicationUrl=' . urlencode( home_url( '/' , 'http' ) ) . '&vip=1';
+			echo '<iframe src="' . esc_url( $dashboard_path ) . '" style="margin: 0 auto;" width="700px" height="900px" frameborder="0" scrolling="no"></iframe>';
 		}
 
 		/**
@@ -357,10 +357,10 @@ if ( ! class_exists( PostRelease_VIP ) ) :
 		 *
 		 * @return void
 		 */
-		public function postrelease_admin_init() {
+		public function admin_init() {
 			$current_db_version = get_option( 'prx_database_version', 0 );
 			if ( $current_db_version < $this->db_version ) {
-				$this->postrelease_upgrade( $this->db_version );
+				$this->upgrade( $this->db_version );
 				update_option( 'prx_database_version', $this->db_version );
 			}
 		}
@@ -370,10 +370,10 @@ if ( ! class_exists( PostRelease_VIP ) ) :
 		 *
 		 * @return void
 		 */
-		public function postrelease_upgrade( $current_db_version ) {
+		public function upgrade( $current_db_version ) {
 			// create template post
 			if ( 1 >= $current_db_version ) {
-				$this->postrelease_check_full_page();
+				$this->check_full_page();
 			}
 		}
 
@@ -382,36 +382,35 @@ if ( ! class_exists( PostRelease_VIP ) ) :
 		 *
 		 * @return void
 		 */
-		public function postrelease_handle_signup_requests() {
+		public function handle_signup_requests() {
 			if ( isset( $_REQUEST['prx'] ) ) {
-				$function = strtolower( sanitize_text_field( $_REQUEST['prx'] ) );
+				$function = strtolower( sanitize_text_field( wp_unslash( $_REQUEST['prx'] ) ) );
 
 				if ( 'prx_generate_key' === $function ) {
-					$this->postrelease_generate_security_key();
+					$this->generate_security_key();
 					exit;
 				}
 
 				// security check, block any requests that do not have the security key
-				$security_check_ok = false || $this->is_dev;
+				$security_check_ok = $this->is_dev;
 
 				if ( isset( $_REQUEST['id'] ) ) { //there is a key saved here
-					$key_url = sanitize_text_field( $_REQUEST['id'] );
-					$security_check_ok = $this->postrelease_is_key_valid( $key_url );
+					$key_url = sanitize_text_field( wp_unslash( $_REQUEST['id'] ) );
+					$security_check_ok = $this->is_key_valid( $key_url );
 				}
 
 				// these functions require security check to be called
-				if ( $security_check_ok && $this->postrelease_authenticate_IP() ) {
+				if ( $security_check_ok && $this->authenticate_ip() ) {
 					// enable plugin during sign up process
 					if ( 'enable' === $function ) {
 						if ( isset( $_REQUEST['status'] ) ) {
-							$this->postrelease_enable_plugin( sanitize_text_field( $_REQUEST['status'] ) );
-						 // get latest posts so that our server can index blog's content
+							$this->enable_plugin( sanitize_text_field( wp_unslash( $_REQUEST['status'] ) ) );
 						} else if ( 'getposts' === $function ) {
-							$this->postrelease_get_posts_xml_for_indexing();
+							$this->get_posts_xml_for_indexing();
 						} else if ( 'status' === $function ) {
-							$this->postrelease_get_status();
+							$this->get_status();
 						} else if ( 'check' === $function ) {
-							$this->postrelease_get_check();
+							$this->get_check();
 						}
 						exit;
 					}
@@ -424,14 +423,14 @@ if ( ! class_exists( PostRelease_VIP ) ) :
 		 *
 		 * @return void
 		 */
-		public function postrelease_handle_enable_request() {
+		public function handle_enable_request() {
 			if (
 				isset( $_GET['do'] )
 				&& 'update' == $_GET['do']
 				&& isset( $_GET['postrelease_enable'] )
 				&& '1' == $_GET['postrelease_enable']
 			) {
-				$this->postrelease_send_success_response();
+				$this->send_success_response();
 				exit;
 			}
 		}
@@ -444,14 +443,14 @@ if ( ! class_exists( PostRelease_VIP ) ) :
 		 *
 		 * @return void, outputs XML
 		 */
-		public function postrelease_get_posts_xml_for_indexing() {
+		public function get_posts_xml_for_indexing() {
 			// by default return 200 posts
 			$default_number_posts = 200;
 
 			// sanitizing num URL parameter
 			$number_posts = isset( $_REQUEST['num'] ) ? intval( $_REQUEST['num'] ) : 0;
 
-			if ( 0 > $number_posts || 200 < $number_posts ) {
+			if ( 1 > $number_posts || 200 < $number_posts ) {
 				$number_posts = $default_number_posts;
 			}
 
@@ -462,39 +461,41 @@ if ( ! class_exists( PostRelease_VIP ) ) :
 			];
 			$posts_for_xml = new WP_Query( $args );
 
-			if ( $posts_for_xml->have_posts() ) {
-				$xml = '<?xml version="1.0" encoding="UTF-8" ?>';
-				$xml .= '<articles>';
-				while ( $posts_for_xml->have_posts() ) : $posts_for_xml->the_post();
-					$xml .= '<article>';
-					$xml .= '<id>' . intval( get_the_ID() ) . '</id>';
-					$xml .= '<link><![CDATA[' . esc_url( get_permalink() ) . ']]></link>';
-					$xml .= '<title><![CDATA[' . wp_kses( get_the_title(), [] ) . ']]></title>';
-					$xml .= '<content><![CDATA[' . wp_kses_post( get_the_content() ) . ']]></content>';
-					$xml .= '</article>';
-				endwhile;
-				$xml .= '</articles>';
-				echo $xml;
-			}
+			if ( $posts_for_xml->have_posts() ) :
+			?>
+				<?php echo '<?xml version="1.0" encoding="UTF-8" ?>'; // phpcs flags w/o echoing. ?>
+				<articles>;
+				<?php while ( $posts_for_xml->have_posts() ) : $posts_for_xml->the_post(); ?>
+					<article>
+						<id><?php echo intval( get_the_ID() ); ?></id>
+						<link><?php echo '<![CDATA[' . esc_url( get_permalink() ) . ']]>'; ?></link>
+						<title><?php echo '<![CDATA[' . esc_html( get_the_title() ) . ']]>'; ?></title>
+						<content><?php echo '<![CDATA[' . wp_kses_post( get_the_content() ) . ']]>'; ?></content>
+					</article>
+				<?php endwhile; ?>
+				</articles>
+			<?php
+			endif;
 		}
 
 		/**
 		 * Does nothing and just returns a result=1 json
 		 * This is called by sign up process (always returns 1)
-		 * The plugin will be enabled with the prx=enable call (function postrelease_enable_plugin)
+		 * The plugin will be enabled with the prx=enable call (method enable_plugin)
 		 * We need to maintain this call because it's part of server sign up process
 		 *
 		 * @return void, outputs html
 		 */
-		public function postrelease_send_success_response() {
-			if ( preg_match( '/\W/', $_REQUEST['callback'] ) ) {
+		public function send_success_response() {
+			if ( isset( $_REQUEST['callback'] ) && preg_match( '/\W/', sanitize_text_field( wp_unslash( $_REQUEST['callback'] ) ) ) ) {
 				header( 'HTTP/1.1 400 Bad Request' );
 				exit;
 			}
 			header( 'Cache-Control: no-cache, must-revalidate' );
 			header( 'Content-type: application/javascript; charset=utf-8' );
 			$data = [ 'result' => 1 ];
-			echo esc_html( sprintf( '%s(%s);', $_REQUEST['callback'], wp_json_encode( $data ) ) );
+			$callback = sanitize_text_field( wp_unslash( $_REQUEST['callback'] ) );
+			echo esc_html( sprintf( '%s(%s);', $callback, wp_json_encode( $data ) ) );
 		}
 
 		/**
@@ -505,21 +506,20 @@ if ( ! class_exists( PostRelease_VIP ) ) :
 		 *
 		 * @return void
 		 */
-		public function postrelease_generate_security_key() {
+		public function generate_security_key() {
 			// if key already exists
 			if ( false !== get_option( 'prx_plugin_key', false ) ) {
 				echo 'FAIL: key already exists';
 				return;
 			}
 
-			if ( postrelease_authenticate_IP() ) {
+			if ( $this->authenticate_ip() ) {
 				$key = wp_generate_password( 10, false, false );
 				update_option( 'prx_plugin_key', $key );
 				$data['Key'] = $key;
-				$output = wp_json_encode( $data );
-				echo $output;
+				echo wp_json_encode( $data );
 			} else {
-				echo 'FAIL: IP authentication error';
+				esc_html_e( 'FAIL: IP authentication error', 'nativo' );
 			}
 		}
 
@@ -530,14 +530,13 @@ if ( ! class_exists( PostRelease_VIP ) ) :
 		 *
 		 * @return void
 		 */
-		public function postrelease_get_status() {
-			$response = [];
-			$response['PublicationTitle'] = postrelease_get_blog_name();
-			$response['Enabled'] = get_option( 'prx_plugin_activated' );
-			$response['PlatformVersion'] = get_bloginfo( 'version' );
-			$response['PluginVersion'] = PRX_WP_PLUGIN_VERSION . '.vip';
-			$output = wp_json_encode( $response );
-			echo $output;
+		public function get_status() {
+			$response                     = [];
+			$response['PublicationTitle'] = $this->get_blog_name();
+			$response['Enabled']          = get_option( 'prx_plugin_activated' );
+			$response['PlatformVersion']  = get_bloginfo( 'version' );
+			$response['PluginVersion']    = $this->plugin_version . '.vip';
+			echo wp_json_encode( $response );
 		}
 
 		/**
@@ -545,21 +544,20 @@ if ( ! class_exists( PostRelease_VIP ) ) :
 		 *
 		 * @return void, outputs JSON
 		 */
-		public function postrelease_get_check() {
-			$response = [];
-			$response['plugin_activated'] = get_option( 'prx_plugin_activated' );
-			$response['site_url'] = site_url();
-			$response['plugin_version'] = PRX_WP_PLUGIN_VERSION . '.vip';
-			$response['postrelease_server'] = PRX_POSTRELEASE_SERVER;
-			$response['javascript_url'] = PRX_JAVASCRIPT_URL;
-			$response['db_version'] = PRX_DB_VERSION;
-			$response['php_version'] = phpversion();
-			$response['wordpress_version'] = get_bloginfo( 'version' );
-			$response['blog_title'] = postrelease_get_blog_name();
-			$response['template_post_id'] = get_option( 'prx_template_post_id', '-1' );
-			$response['prx_dev'] = PRX_DEV;
-			$output = wp_json_encode( $response );
-			echo $output;
+		public function get_check() {
+			$response                       = [];
+			$response['plugin_activated']   = get_option( 'prx_plugin_activated' );
+			$response['site_url']           = site_url();
+			$response['plugin_version']     = $this->plugin_version . '.vip';
+			$response['postrelease_server'] = $this->server;
+			$response['javascript_url']     = $this->js_url;
+			$response['db_version']         = $this->db_version;
+			$response['php_version']        = phpversion();
+			$response['wordpress_version']  = get_bloginfo( 'version' );
+			$response['blog_title']         = $this->get_blog_name();
+			$response['template_post_id']   = get_option( 'prx_template_post_id', '-1' );
+			$response['prx_dev']            = $this->is_dev;
+			echo wp_json_encode( $response );
 		}
 
 		/**
@@ -570,17 +568,17 @@ if ( ! class_exists( PostRelease_VIP ) ) :
 		 *
 		 * @return void, outputs JSON
 		 */
-		public function postrelease_enable_plugin( $enable ) {
+		public function enable_plugin( $enable ) {
 			$enable = intval( $enable );
 			$data['result'] = 0;
 
 			if ( 1 === $enable || 0 === $enable ) {
 				// plugin activated changed
-				if ( $enable !== intval( get_option( 'prx_plugin_activated') ) ) {
+				if ( intval( get_option( 'prx_plugin_activated' ) ) !== $enable ) {
 					if ( 0 === $enable ) {
-						$this->postrelease_deactivate();
+						$this->deactivate();
 					} else if ( 1 === $enable ) {
-						$this->postrelease_activate();
+						$this->activate();
 					}
 				}
 				update_option( 'prx_plugin_activated', (int) $enable );
@@ -593,8 +591,8 @@ if ( ! class_exists( PostRelease_VIP ) ) :
 		 * Return the blog name.
 		 * If it's not set, return the blog URL.
 		 */
-		public function postrelease_get_blog_name() {
-			if ( 0 === strlen( trim( get_bloginfo( 'name') ) ) ) {
+		public function get_blog_name() {
+			if ( 0 === strlen( trim( get_bloginfo( 'name' ) ) ) ) {
 				return site_url();
 			} else {
 				return get_bloginfo( 'name' );
@@ -604,10 +602,10 @@ if ( ! class_exists( PostRelease_VIP ) ) :
 		/**
 		 * Change author display name to "Promoted" in secondary impression
 		 */
-		public function postrelease_the_author( $author ) {
+		public function the_author( $author ) {
 			global $post;
 			$template_post_id = get_option( 'prx_template_post_id' );
-			if ( ! empty( $post->ID ) && ( $post->ID === intval( get_option( 'prx_template_post_id', -1 ) ) ) ) {
+			if ( ! empty( $post->ID ) && ( intval( get_option( 'prx_template_post_id', -1 ) ) === $post->ID ) ) {
 				$author = 'Promoted';
 			}
 			return $author;
@@ -616,9 +614,9 @@ if ( ! class_exists( PostRelease_VIP ) ) :
 		/**
 		 * Change author link to blog homepage URL in secondary impression
 		 */
-		public function postrelease_author_link( $link, $author_id ) {
+		public function author_link( $link, $author_id ) {
 			global $post;
-			if ( ! empty( $post->ID ) && ( $post->ID === intval( get_option( 'prx_template_post_id', -1 ) ) ) ) {
+			if ( ! empty( $post->ID ) && ( intval( get_option( 'prx_template_post_id', -1 ) ) === $post->ID ) ) {
 				$link = esc_url( get_home_url( $post->ID ) );
 			}
 			return $link;
@@ -632,9 +630,9 @@ if ( ! class_exists( PostRelease_VIP ) ) :
 		 * @param  string $format    the date format
 		 * @return string            formatted date
 		 */
-		public function postrelease_get_the_date_time( $date_time, $format ) {
+		public function get_the_date_time( $date_time, $format ) {
 			global $post;
-			if ( $post->ID == get_option( 'prx_template_post_id', -1 ) ) {
+			if ( intval( get_option( 'prx_template_post_id', -1 ) ) === $post->ID ) {
 				$date_time = date( $d, time() );
 			}
 			return $date_time;
@@ -645,15 +643,15 @@ if ( ! class_exists( PostRelease_VIP ) ) :
 		 *
 		 * @return boolean
 		 */
-		public function postrelease_notify_activate() {
+		public function notify_activate() {
 			// notify PostRelease team that plugin was activated
 			$args = [
-				'method' => 'POST',
-				'timeout' => 2,
+				'method'     => 'POST',
+				'timeout'    => 2,
 				'user-agent' => 'Wordpress_plugin',
-				'sslverify' => true,
+				'sslverify'  => true,
 			];
-			$url = rawurlencode( $this->postrelease_server . 'plugins/Api/PluginActivated?url=' . site_url() );
+			$url = rawurlencode( $this->server . 'plugins/Api/PluginActivated?url=' . site_url() );
 			return is_wp_error( wp_safe_remote_post( $url, $args ) );
 		}
 
@@ -662,20 +660,20 @@ if ( ! class_exists( PostRelease_VIP ) ) :
 		 *
 		 * @return boolean
 		 */
-		public function postrelease_notify_deactivate() {
+		public function notify_deactivate() {
 			// notify PostRelease team that plugin was deactivated
 			$args = [
-				'method' => 'POST',
-				'timeout' => 2,
+				'method'     => 'POST',
+				'timeout'    => 2,
 				'user-agent' => 'Wordpress_plugin',
-				'sslverify' => true,
+				'sslverify'  => true,
 			];
-			$url = rawurlencode( $this->postrelease_server . 'plugins/Api/PluginDeactivated?url=' . site_url() );
+			$url = rawurlencode( $this->server . 'plugins/Api/PluginDeactivated?url=' . site_url() );
 			return is_wp_error( wp_safe_remote_post( $url, $args ) );
 		}
 
 	}
 
-	PostRelease_VIP::get_instance();
+	Nativo::get_instance();
 
-endif;
+} // End if().

--- a/postrelease-vip.php
+++ b/postrelease-vip.php
@@ -336,7 +336,7 @@ if ( ! class_exists( PostRelease_VIP ) ) :
 		 */
 		public function postrelease_create_menu() {
 			// Add PostRelease menu item under the "Settings" top-level menu
-			add_submenu_page( 'options-general.php', __( 'PostRelease Dashboard', 'lin' ), __( 'PostRelease', 'lin' ), 'manage_options', 'postrelease', 'postrelease_settings_page' );
+			add_submenu_page( 'options-general.php', __( 'PostRelease Dashboard', 'nativo' ), __( 'PostRelease', 'nativo' ), 'manage_options', 'postrelease', 'postrelease_settings_page' );
 		}
 
 		/**

--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,16 @@
+# PostRelease VIP #
+
+A plugin to handle ad placement through Nativo
+
+### Release Notes ###
+1.0 - 2012/08/01
+First release live
+
+1.1 - 2012/10/05
+Returning blog URL as the blog name as fallback
+
+1.2 - 2012/10/08
+Added filters for date and author (display as Promoted)
+
+1.3 - 2017/01/19
+Refactor/bring up to WordPress VIP code standards

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * PHPUnit bootstrap file
+ *
+ * @package Postrelease_Vip
+ */
+
+$_tests_dir = getenv( 'WP_TESTS_DIR' );
+if ( ! $_tests_dir ) {
+	$_tests_dir = '/tmp/wordpress-tests-lib';
+}
+
+// Give access to tests_add_filter() function.
+require_once $_tests_dir . '/includes/functions.php';
+
+/**
+ * Manually load the plugin being tested.
+ */
+function _manually_load_plugin() {
+	require dirname( dirname( __FILE__ ) ) . '/postrelease-vip.php';
+}
+tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
+
+// Start up the WP testing environment.
+require $_tests_dir . '/includes/bootstrap.php';

--- a/tests/test-nativo.php
+++ b/tests/test-nativo.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * Class NativoTests
+ *
+ */
+class NativoTests extends WP_UnitTestCase {
+
+	protected $post_type = 'pr_sponsored_post';
+
+	protected $current_user, $post_id, $posts, $password;
+
+	public function setUp() {
+		parent::setUp();
+
+		// Current user
+		$this->current_user = wp_set_current_user( 1 );
+
+		$single_post_args = [
+			'post_title'     => '<span class="prx_title"></span>',
+			'post_content'   => '<span class="prx_body"></span>',
+			'post_type'      => $this->post_type,
+			'post_status'    => 'publish',
+			'post_author'    => $this->current_user->ID,
+			'post_name'      => 'postrelease',
+			'post_date'      => '1960-01-01 00:0:00',
+			'post_date_gmt'  => '1960-01-01 00:00:00',
+			'comment_status' => 'closed',
+			'ping_status'    => 'closed',
+		];
+
+		// Generated password
+		$this->password = wp_generate_password( 10, false, false );
+
+		// Create a test post.
+		$this->post_id = $this->factory->post->create( $single_post_args );
+
+		// Create 5 test posts
+		$this->posts = $this->factory->post->create_many( 5, $single_post_args );
+
+		// Create
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+	}
+
+	public function test_pr_sponsored_post_custom_post_type_creation() {
+		global $wp_post_types;
+		$this->assertArrayHasKey( $this->post_type, $wp_post_types );
+	}
+
+	public function test_create_page() {
+		// Does the test post created exist.
+		$post = get_post( $this->post_id );
+		$this->assertEquals( $this->post_id, $post->ID );
+
+		// Test the option update
+		$this->assertTrue( update_option( 'prx_template_post_id', $this->post_id ) );
+	}
+
+	/**
+	 * Test removal of sponsored posts
+	 */
+	public function test_sponsored_posts_removal() {
+		foreach ( $this->posts as $id ) {
+			$this->assertNotFalse( wp_delete_post( $id, true ) );
+		}
+	}
+
+	public function test_options_removal() {
+		update_option( 'prx_template_post_id', 1 );
+		$this->assertTrue( delete_option( 'prx_template_post_id' ) );
+
+		update_option( 'prx_plugin_activated', true );
+		$this->assertTrue( delete_option( 'prx_plugin_activated' ) );
+
+		update_option( 'prx_plugin_key', $this->password );
+		$this->assertTrue( delete_option( 'prx_plugin_key' ) );
+
+		update_option( 'prx_database_version', 1 );
+		$this->assertTrue( delete_option( 'prx_database_version' ) );
+	}
+
+	public function test_is_key_valid() {
+		update_option( 'prx_plugin_key', $this->password );
+		$md5_key = md5( get_option( 'prx_plugin_key' ) );
+		$this->assertEquals( $md5_key, md5( $this->password ) );
+	}
+
+	// public function test_ () {
+
+	// }
+
+	// public function test_ () {
+
+	// }
+
+	// public function test_ () {
+
+	// }
+
+	// public function test_ () {
+
+	// }
+}

--- a/wpcom-helper.php
+++ b/wpcom-helper.php
@@ -4,6 +4,7 @@ add_action( 'postrelease_activate', 'wpcom_postrelease_activate_flush_rules' );
 
 function wpcom_postrelease_activate_flush_rules() {
 	// TODO: we should have a standalone function for flushing rules on WP.com, in VIP helpers
-	if ( function_exists( 'rri_wpcom_flush_rules' ) )
-		rri_wpcom_flush_rules();	
+	if ( function_exists( 'rri_wpcom_flush_rules' ) ) {
+		rri_wpcom_flush_rules();
+	}
 }


### PR DESCRIPTION
This is for the refactoring of the postrelease-vip plugin for Nativo to be included in sites on WordPress.com VIP. This plugin hasn't been updated in some time.

Some items of note:

- Moved version history into new readme.md file. Not sure versioning is needed for this, but added to it anyway.
- Converted procedural code into a singleton class.
- Removed some (what seemed like) redundant functions/methods and consolidated actions/filters accordingly. This plugin was using two actions that seemed like they should be filters, so they were changed to filters and duplicate callbacks were removed. ex.: `add_action('the_author', 'postrelease_the_author')` & `add_action('the_author_display_name', 'postrelease_the_author_display_name')`. These changes definitely need to be tested further.
- Fixed spacing, yoda conditionals, replaced no-VIP approved functions with VIP versions (including `get_posts()` which is not cached, with `WP_Query()`), put in variable checks before using, etc.
- Moved constants in the config file into the class. Not sure a secondary file was really necessary. Open to opinions on this.
- Left the `wpcom-helper.php` file in the plugin root, but cleaned up some brackets. This must be a file used by VIP as it was not php required/included in any plugin file originally.

This is my first go around on a refactor for VIP, so definitely open to any suggestions. This code has not been tested other than making sure it's included in the theme's `functions.php` file and throws no PHP errors, warnings, etc. It's my understanding that we need keys, etc. from the client, but I still need to look into that and this will need further testing.